### PR TITLE
fix: corrected api call

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,8 @@ gem "importmap-rails", "~> 1.1"
 
 gem 'redis'
 
+gem 'sassc-rails'
+
 group :test do
   gem 'rspec'
 end

--- a/app/controllers/hello_controller.rb
+++ b/app/controllers/hello_controller.rb
@@ -11,10 +11,9 @@ class HelloController < ApplicationController
 
   def create_organization
     params = create_organization_params
-    # might be `@client.organizations.create_organization(create_organization_request: {name: "new_org"})` as well
     wrap_with_mgmt_client_checking do
       @client.organizations.create_organization(
-        create_organization_request: KindeApi::CreateOrganizationRequest.new(name: params[:name])
+        name: params[:name]
       )
     end
   end


### PR DESCRIPTION
# Explain your changes

Corrected the starter to used the current create organisation API.
# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Streamlined organization creation process by simplifying the request structure.
	- Added new dependency `sassc-rails` to enhance styling capabilities.

- **Bug Fixes**
	- Improved efficiency in the `create_organization` method without altering its overall functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->