### PR TITLE
fix: changed to use the rails engine

### DIFF
--- a/app/views/hello/mgmt_index.html.erb
+++ b/app/views/hello/mgmt_index.html.erb
@@ -36,7 +36,7 @@
     <% end %>
   </div>
 <% else %>
-  <a class="button is-primary" href="<%= kinde_sdk_client_credentials_auth_path %>">
+  <a class="button is-primary" href="<%= kinde_sdk.client_credentials_auth_path %>">
     <strong>Log in M2M</strong>
   </a>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
 
 <body>
 <nav class="navbar is-primary" role="navigation" aria-label="main navigation">
-  <div id="navbarBasicExample" class="navbar-menu">
+   <id="navbarBasicExample" class="navbar-menu">
     <div class="navbar-start">
       <a class="navbar-item" href="/">Home</a>
       <a class="navbar-item" href="/mgmt">Management API</a>
@@ -20,27 +20,27 @@
 
     <div class="navbar-end">
       <div class="navbar-item">
-        <div class="buttons">
-          <% if logged_in? %>
-            <a class="button is-primary" href="<%= kinde_sdk_logout_path %>">
-              <strong>Logout</strong>
-            </a>
-          <% else %>
-            <a class="button is-primary" href="<%= kinde_sdk_auth_path %>">
-              <strong>Log in</strong>
-            </a>
-          <% end %>
-        </div>
+      <div class="buttons">
+        <% if logged_in? %>
+        <a class="button is-primary" href="<%= kinde_sdk.logout_path %>">
+          <strong>Logout</strong>
+        </a>
+        <% else %>
+        <a class="button is-primary" href="<%= kinde_sdk.auth_path %>">
+          <strong>Log in</strong>
+        </a>
+        <% end %>
+      </div>
       </div>
     </div>
-  </div>
-</nav>
-<section class="section">
-  <%= render 'shared/flashes' %>
+    </div>
+  </nav>
+  <section class="section">
+    <%= render 'shared/flashes' %>
 
-  <div class="content">
+    <div class="content">
     <%= yield %>
-  </div>
-</section>
-</body>
-</html>
+    </div>
+  </section>
+  </body>
+  </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,11 +8,5 @@ Rails.application.routes.draw do
   post "mgmt_create_organization" => "hello#create_organization"
   post "mgmt_create_user" => "hello#create_user"
 
-  namespace :kinde_sdk do
-    get "callback" => "auth#callback"
-    get "auth" => "auth#auth"
-    get "logout" => "auth#logout"
-    get "logout_callback" => "auth#logout_callback"
-    get "client_credentials_auth" => "auth#client_credentials_auth"
-  end
+  mount KindeSdk::Engine, at: "/kinde_sdk"
 end


### PR DESCRIPTION
# Explain your changes

Change the starter to use the newly exposed rails engine.

# Checklist

- [ ] I have read the [“Pull requests” section](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CONTRIBUTING.md).
- [ ] I agree to the terms within the [code of conduct](https://github.com/kinde-starter-kits/.github/blob/ff8d5c462e56772810bca53f750fd3610a00d673/.github/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
